### PR TITLE
Rosterredux

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@airship/with-unstated": "^1.0.1",
+    "@react-native-community/async-storage": "^1.6.2",
     "axios": "^0.18.1",
     "expo": "^35.0.0",
     "expo-asset": "~7.0.0",

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,8 +1,8 @@
 // Production
-export const HYMNAL_ADDRESS = 'https://chattahooligan-hymnal.herokuapp.com'
+//export const HYMNAL_ADDRESS = 'https://chattahooligan-hymnal.herokuapp.com'
 
 // Dev
- //export const HYMNAL_ADDRESS = 'https://guardbook-beta.herokuapp.com'
+export const HYMNAL_ADDRESS = 'https://guardbook-beta.herokuapp.com'
 
   //= 'https://hymn-test.herokuapp.com';
 // process.env.NODE_ENV === 'development'

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,9 +1,9 @@
 // Production
-export const HYMNAL_ADDRESS = 'https://chattahooligan-hymnal.herokuapp.com'
+//export const HYMNAL_ADDRESS = 'https://chattahooligan-hymnal.herokuapp.com'
 //export const HYMNAL_ADDRESS = 'https://radiant-citadel-22556.herokuapp.com'
 
 // Dev
-//export const HYMNAL_ADDRESS = 'https://guardbook-beta.herokuapp.com'
+export const HYMNAL_ADDRESS = 'https://guardbook-beta.herokuapp.com'
 
   //= 'https://hymn-test.herokuapp.com';
 // process.env.NODE_ENV === 'development'

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -2,7 +2,7 @@
 export const HYMNAL_ADDRESS = 'https://chattahooligan-hymnal.herokuapp.com'
 
 // Dev
-// export const HYMNAL_ADDRESS = 'https://hymn-test.herokuapp.com'
+ //export const HYMNAL_ADDRESS = 'https://guardbook-beta.herokuapp.com'
 
   //= 'https://hymn-test.herokuapp.com';
 // process.env.NODE_ENV === 'development'

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,8 +1,9 @@
 // Production
-//export const HYMNAL_ADDRESS = 'https://chattahooligan-hymnal.herokuapp.com'
+export const HYMNAL_ADDRESS = 'https://chattahooligan-hymnal.herokuapp.com'
+//export const HYMNAL_ADDRESS = 'https://radiant-citadel-22556.herokuapp.com'
 
 // Dev
-export const HYMNAL_ADDRESS = 'https://guardbook-beta.herokuapp.com'
+//export const HYMNAL_ADDRESS = 'https://guardbook-beta.herokuapp.com'
 
   //= 'https://hymn-test.herokuapp.com';
 // process.env.NODE_ENV === 'development'

--- a/src/containers/GlobalDataContainer.js
+++ b/src/containers/GlobalDataContainer.js
@@ -29,10 +29,10 @@ export default class GlobalDataContainer extends Container {
       chapters: []
     },
     songs: null,
-    roster: {
+    rosters: {
       rosterTitle: '',
       season: '',
-      squads: []
+      players: []
     },
     players: null,
     foes: null,
@@ -50,14 +50,15 @@ export default class GlobalDataContainer extends Container {
       const songbook = await getSongbook();
 
       const players = await getPlayers();
-      const roster = await getRoster();
+      const rosters = await getRoster();
       const foes = await getFoes();
       
+      this.setState({ songbook: songbook[0], songs, rosters: rosters, players, htmlColors, foes });
       this.setState({ 
         songbook: songbook[0], 
         songs, 
         players, 
-        roster: this.verifyRoster(players,roster[0]), 
+        rosters: this.verifyRoster(players,rosters), 
         foes, 
         htmlColors });
     } catch (e) {
@@ -65,13 +66,13 @@ export default class GlobalDataContainer extends Container {
     }
   };
 
-  verifyRoster = (players,roster) => {
-    let squads = [];
+  verifyRoster = (players,rosters) => {
+    let rosterList = [];
 
-    roster.squads.forEach(squadChild => {
+    rosters.forEach(roster => {
       let playerList = [];
 
-      squadChild.players.forEach(playerChild => {
+      roster.players.forEach(playerChild => {
         try {
           let player = players.find(player => player._id === playerChild._id);
 
@@ -85,12 +86,11 @@ export default class GlobalDataContainer extends Container {
       });
 
       if (0 < playerList.length)
-        squads.push({ _id: squadChild._id, squadTitle: squadChild.squadTitle, players: playerList });
+        rosterList.push({ _id: roster._id, squadTitle: roster.rosterTitle, players: playerList });
     });
 
-    roster.squads = squads;
-    
-    return roster;
+    //roster.squads = squads;
+    return rosterList;
   }
 
   getLocationAsync = async () => {

--- a/src/containers/GlobalDataContainer.js
+++ b/src/containers/GlobalDataContainer.js
@@ -191,7 +191,7 @@ export default class GlobalDataContainer extends Container {
 
   toggleUserAuth = value => this.setState({ unlocked: !this.state.unlocked });
 
-  setAuthKey = authKey => this.setState({ apiAuthKey: authKey });
+  setBearerToken = bearerToken => this.setState({ bearerToken });
 
-  getAuthKey = () => { return this.state.apiAuthKey; }
+  getBearerToken = () => { return this.state.bearerToken; }
 }

--- a/src/containers/GlobalDataContainer.js
+++ b/src/containers/GlobalDataContainer.js
@@ -86,7 +86,7 @@ export default class GlobalDataContainer extends Container {
       });
 
       if (0 < playerList.length)
-        rosterList.push({ _id: roster._id, squadTitle: roster.rosterTitle, players: playerList });
+        rosterList.push({ _id: roster._id, rosterTitle: roster.rosterTitle, players: playerList });
     });
 
     //roster.squads = squads;

--- a/src/containers/GlobalDataContainer.js
+++ b/src/containers/GlobalDataContainer.js
@@ -40,7 +40,6 @@ export default class GlobalDataContainer extends Container {
     goalkeeperNickname: null,
     htmlColors: null,
     token: null,
-    unlocked: false,
     response: null
   };
 
@@ -86,7 +85,7 @@ export default class GlobalDataContainer extends Container {
       });
 
       if (0 < playerList.length)
-        rosterList.push({ _id: roster._id, rosterTitle: roster.rosterTitle, players: playerList });
+        rosterList.push({ _id: roster._id, rosterTitle: roster.rosterTitle, players: playerList, default: roster.default });
     });
 
     //roster.squads = squads;
@@ -188,8 +187,6 @@ export default class GlobalDataContainer extends Container {
 
 
   setLocation = location => this.setState({ location });
-
-  toggleUserAuth = value => this.setState({ unlocked: !this.state.unlocked });
 
   setBearerToken = bearerToken => this.setState({ bearerToken });
 

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,9 +1,8 @@
 import _ from 'lodash';
 
 export const getFeaturedSong = (songbook, allSongs) => {
-  if (songbook && allSongs && allSongs.length) {
+  if (songbook && allSongs && allSongs.length && songbook.chapters) {
     let featuredSongs = [];
-
     songbook.chapters.forEach(chapter => {
       chapter.songs.forEach(songChild => {
         if (songChild.featured) {

--- a/src/screens/CapoConfirmSendGoalkeeperNickname.js
+++ b/src/screens/CapoConfirmSendGoalkeeperNickname.js
@@ -124,16 +124,15 @@ class CapoConfirmSendGoalkeeperNickname extends React.Component {
     const { goalkeeperNickname, token } = this.props.globalData.state;
 
     let nickname = new RemoteGoalkeeperNickname();
-
+    let bearerToken = "Bearer " + this.props.globalData.getBearerToken();
     nickname
       .create({
         sender: token,
         push: pushFlag,
         nickname: goalkeeperNickname.nickname,
         backgroundColor: goalkeeperNickname.backgroundColor,
-        textColor: goalkeeperNickname.textColor,
-        authKey: this.props.globalData.getAuthKey()
-      })
+        textColor: goalkeeperNickname.textColor
+      }, bearerToken)
       .then(responseJson => {
         // this is the output from the server for sending our capo_message
         console.log(JSON.stringify(responseJson));

--- a/src/screens/CapoConfirmSendSong.js
+++ b/src/screens/CapoConfirmSendSong.js
@@ -136,7 +136,7 @@ class CapoConfirmSendSong extends React.Component {
     //console.log('---- object to wrap in a message to server ----\n', CapoMessageSchema);
 
     let notifications = new RemoteNotifications();
-
+    let bearerToken = "Bearer " + this.props.globalData.getBearerToken();
     notifications
       .create({
         sender: CapoMessageSchema.sender,
@@ -147,13 +147,11 @@ class CapoConfirmSendSong extends React.Component {
         push: pushFlag,
         announcement: null,
         song: CapoMessageSchema.song,
-        goalkeeperNickname: null,
-        authKey: this.props.globalData.getAuthKey()
-      })
+        goalkeeperNickname: null
+      }, bearerToken)
       .then(responseJson => {
         // this is the output from the server for sending our capo_message
         console.log(JSON.stringify(responseJson));
-
         this.props.globalData.setResponse(responseJson);
         // we REALLY need to confirm this got sent
         //alert("success or fail message? do we even know?");

--- a/src/screens/CapoLogin.js
+++ b/src/screens/CapoLogin.js
@@ -34,7 +34,8 @@ class CapoLogin extends React.Component {
   };
 
   state = {
-    password: ''
+    password: '',
+    username: ''
   };
 
   componentDidMount() {
@@ -51,12 +52,20 @@ class CapoLogin extends React.Component {
   render() {
     return (
       <View style={styles.container}>
-        <RegularText style={styles.instructions}>Enter password to unlock</RegularText>
+        <RegularText style={styles.instructions}>Username/Email</RegularText>
+        <TextInput
+          style={styles.textInput}
+          autoFocus={true}
+          onChangeText={this._setUsername}
+          value={this.state.value}
+        />
+        <RegularText style={styles.instructions}>Password</RegularText>
         <TextInput
           style={styles.textInput}
           autoFocus={true}
           onChangeText={this._setPassword}
           value={this.state.value}
+          secureTextEntry={true}
         />
         <ClipBorderRadius>
           <RectButton
@@ -72,16 +81,20 @@ class CapoLogin extends React.Component {
   }
 
   _setPassword = password => this.setState({ password });
+  _setUsername = username => this.setState({ username });
 
   _handlePressSubmitButton = () => {
     let authChecker = new AuthCheck();
     authChecker
       .check({
-        authKey: this.state.password
+        email: this.state.username,
+        password: this.state.password,
+        rememberMe: true
       })
       .then(responseJson => {
+        console.log(responseJson);
         Keyboard.dismiss();
-        this.props.globalData.setAuthKey(this.state.password);
+        this.props.globalData.setBearerToken(responseJson.token);
         this.props.globalData.toggleUserAuth();
         this.props.navigation.navigate('CapoHome');
       })
@@ -115,11 +128,13 @@ const styles = StyleSheet.create({
     paddingTop: 15
   },
   instructions: {
-    fontSize: 18
+    fontSize: 18,
+    paddingLeft: 15
   },
   textInput: {
     fontSize: 18,
-    padding: 8
+    padding: 8,
+    paddingLeft: 15
   },
   bigButton: {
     backgroundColor: DefaultColors.ButtonBackground,

--- a/src/screens/CapoLogin.js
+++ b/src/screens/CapoLogin.js
@@ -45,7 +45,6 @@ class CapoLogin extends React.Component {
 
   setData = () => {
     var token = this.props.globalData.getBearerToken();
-    console.log(token);
     if(token !== "") {
       //token is present from previous login
       //check if still valid and bypass login if so
@@ -118,8 +117,7 @@ class CapoLogin extends React.Component {
     authChecker
       .check({
         email: this.state.username,
-        password: this.state.password,
-        rememberMe: true
+        password: this.state.password
       })
       .then(responseJson => {
         Keyboard.dismiss();

--- a/src/screens/Roster.js
+++ b/src/screens/Roster.js
@@ -127,11 +127,19 @@ class Roster extends React.Component {
   }
 
   setData = () => {
-    let rosters = this.props.globalData.state.rosters
-    if (rosters.length > 0)
-      this.setState({ rosters, currentRosterID: rosters[0]._id });
-    else
+    let rosters = this.props.globalData.state.rosters;
+    if (rosters.length > 0) {
+      var currentRosterId = rosters[0]._id;
+      //search for a default property. if present, override that to the current id.
+      for(let i = 0; i < rosters.length; i++) {
+        if(rosters[i].default) {
+          currentRosterId = rosters[i]._id;
+        }
+      }
+      this.setState({ rosters, currentRosterID: currentRosterId });
+    } else {
       this.setState({ rosters, currentRosterID: null });
+    }
   }
 
   render() {

--- a/src/screens/Roster.js
+++ b/src/screens/Roster.js
@@ -60,7 +60,6 @@ class PlayerRow extends React.Component {
           />
         </TouchableOpacity>    
     }
-
     return (
       <View style={styles.row}>
         <RectButton
@@ -108,9 +107,8 @@ class Roster extends React.Component {
   };
   
   state = {
-    rosterTitle: "Roster",
-    squads: [],
-    currentSquadID: null
+    rosters: [],
+    currentRosterID: null
   }
 
   componentDidMount() {
@@ -121,43 +119,41 @@ class Roster extends React.Component {
     if (
       !prevProps.globalData.state.players &&
       this.props.globalData.state.players ||
-      !prevProps.globalData.state.roster &&
-      this.props.globalData.state.roster
+      !prevProps.globalData.state.rosters &&
+      this.props.globalData.state.rosters
     ) {
       this.setData();
     }
   }
 
   setData = () => {
-    let rosterTitle = this.props.globalData.state.roster.rosterTitle;
-    let squads = this.props.globalData.state.roster.squads;
-
-    if (squads.length > 0)
-      this.setState({ rosterTitle, squads, currentSquadID: squads[0]._id });
+    let rosters = this.props.globalData.state.rosters
+    if (rosters.length > 0)
+      this.setState({ rosters, currentRosterID: rosters[0]._id });
     else
-      this.setState({ rosterTitle, squads, currentSquadID: null });
+      this.setState({ rosters, currentRosterID: null });
   }
 
   render() {
     let listDisplay = null;
     let header = null;
 
-    if (this.state.squads.length > 0)
+    if (this.state.rosters.length > 0)
     {
       let pickerItems = [];
-      this.state.squads.forEach(element => {
-        pickerItems.push(<Picker.Item label={element.squadTitle} value={element._id} key={element._id} />);
+      this.state.rosters.forEach(element => {
+        pickerItems.push(<Picker.Item label={element.rosterTitle} value={element._id} key={element._id} />);
       });
       header = 
         <Picker
           enabled={pickerItems.length > 1}
-          selectedValue={this.state.currentSquadID}
-          onValueChange={(itemValue) => this.setState({currentSquadID: itemValue})}
+          selectedValue={this.state.currentRosterID}
+          onValueChange={(itemValue) => this.setState({currentRosterID: itemValue})}
         >
           {pickerItems}
         </Picker>
   
-      let playerData = this.state.squads.find(element => element._id == this.state.currentSquadID).players;
+      let playerData = this.state.rosters.find(element => element._id == this.state.currentRosterID).players;
   
       listDisplay = 
         <FlatList
@@ -171,7 +167,7 @@ class Roster extends React.Component {
     {
       header = 
         <Picker>
-          <Picker.Item label='No Squads found' />
+          <Picker.Item label='No Rosters found' />
         </Picker>
       listDisplay = <View style={{flex: 1}}/>
     }
@@ -183,7 +179,7 @@ class Roster extends React.Component {
           {header}
           {listDisplay}
           <RectButton
-            enabled={this.state.squads.length > 0}
+            enabled={this.state.rosters.length > 0}
             style={styles.twitterListButtonStyle}
             onPress={this._handlePressTwitterListButton}
             underlayColor="#fff"
@@ -212,7 +208,7 @@ class Roster extends React.Component {
   _renderSectionHeader = ({ section }) => {
     return (
       <View style={styles.sectionHeader}>
-        <RegularText>{section.squadTitle}</RegularText>
+        <RegularText>{section.rosterTitle}</RegularText>
       </View>
     );
   };
@@ -227,8 +223,8 @@ class Roster extends React.Component {
   };
 
   _handlePressTwitterListButton = () => {
-    let squad = this.state.squads.find(element => element._id == this.state.currentSquadID)
-    this.props.navigation.navigate('TwitterList', {squad});
+    let roster = this.state.rosters.find(element => element._id == this.state.currentRosterID)
+    this.props.navigation.navigate('TwitterList', {roster});
   }
 }
 

--- a/src/screens/Roster.js
+++ b/src/screens/Roster.js
@@ -218,7 +218,6 @@ class Roster extends React.Component {
   };
 
   _handlePressRow = player => {
-    // console.log('player click', player.name);
     this.props.navigation.navigate('Player', { player });
   };
 

--- a/src/screens/TwitterList.js
+++ b/src/screens/TwitterList.js
@@ -21,8 +21,7 @@ class TwitterList extends React.Component {
 
   render() {
     let handles = '';
-
-    this.props.navigation.state.params.squad.players.forEach(player => {
+    this.props.navigation.state.params.roster.players.forEach(player => {
       if (player.twitter)
         handles += '@' + player.twitter + ' ';
     });

--- a/src/server_store/AuthCheck.js
+++ b/src/server_store/AuthCheck.js
@@ -21,4 +21,21 @@ export default class AuthCheck extends ApiClient {
       throw new ApiError('Error creating new notification on server', error);
     }
   }
+  
+  async validToken(token) {
+    try {
+      let response = await this.doRequest('users/me', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': token
+        },
+        body: JSON.stringify({})
+      });
+      return await response.json();
+    }
+    catch (error) {
+      throw new ApiError('Error creating new notification on server', error);
+    }
+  }
 };

--- a/src/server_store/AuthCheck.js
+++ b/src/server_store/AuthCheck.js
@@ -8,7 +8,7 @@ export default class AuthCheck extends ApiClient {
   
   async check(code) {
     try {
-      let response = await this.doRequest('authCheck', {
+      let response = await this.doRequest('users/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/src/server_store/AuthCheck.js
+++ b/src/server_store/AuthCheck.js
@@ -29,8 +29,7 @@ export default class AuthCheck extends ApiClient {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': token
-        },
-        body: JSON.stringify({})
+        }
       });
       return await response.json();
     }

--- a/src/server_store/RemoteGoalkeeperNickname.js
+++ b/src/server_store/RemoteGoalkeeperNickname.js
@@ -18,12 +18,13 @@ export default class RemoteNotifications extends ApiClient {
     }
   }
 
-  async create(goalkeeperNickname) {
+  async create(goalkeeperNickname, token) {
     try {
       let response = await this.doRequest('goalkeeperNicknames', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Authorization': token
         },
         body: JSON.stringify(goalkeeperNickname)
       });

--- a/src/server_store/RemoteNotifications.js
+++ b/src/server_store/RemoteNotifications.js
@@ -30,7 +30,6 @@ export default class RemoteNotifications extends ApiClient {
   }
 
   async create(notification, token) {
-    console.log(JSON.stringify(notification));
     try {
       let response = await this.doRequest('notification', {
         method: 'POST',

--- a/src/server_store/RemoteNotifications.js
+++ b/src/server_store/RemoteNotifications.js
@@ -29,12 +29,14 @@ export default class RemoteNotifications extends ApiClient {
     }
   }
 
-  async create(notification) {
+  async create(notification, token) {
+    console.log(JSON.stringify(notification));
     try {
       let response = await this.doRequest('notification', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Authorization': token
         },
         body: JSON.stringify(notification)
       });
@@ -45,12 +47,13 @@ export default class RemoteNotifications extends ApiClient {
     }
   }
 
-  async update(id, notification) {
+  async update(id, notification, token) {
     try {
       let response = await this.doRequest(`notification/${id}`, {
         method: 'PUT',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Authorization': token
         },
         body: JSON.stringify(notification)
       });
@@ -61,9 +64,13 @@ export default class RemoteNotifications extends ApiClient {
     }
   }
 
-  async remove(id) {
+  async remove(id, token) {
     try {
-      await this.doRequest(`notifications/${id}`, { method: 'DELETE' });
+      await this.doRequest(`notifications/${id}`, { 
+        method: 'DELETE', 
+        headers: {
+          'Authorization': token
+      } });
     }
     catch (error) {
       throw new ApiError(`Error deleting notification with id ${id} from server`, error);

--- a/src/services/rosterService.js
+++ b/src/services/rosterService.js
@@ -1,4 +1,4 @@
 import API from './baseService';
 
 export const getRoster = () =>
-  API.get('/api/roster').then(response => response.data);
+  API.get('/api/roster/active').then(response => response.data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,6 +1593,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@react-native-community/async-storage@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.6.2.tgz#a19ca7149c4dfe8216f2330e6b1ebfe2d075ef92"
+  integrity sha512-EJGsbrHubK1mGxPjWB74AaHAd5m9I+Gg2RRPZzMK6org7QOU9WOBnIMFqoeVto3hKOaEPlk8NV74H6G34/2pZQ==
+
 "@react-native-community/cli@^1.2.1":
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-1.11.2.tgz#b14967f24a389f5a16889a747345cf0e5757a2f1"


### PR DESCRIPTION
THIS BRANCH IS A BREAKING CHANGE! READ THIS CLOSELY!

To merge this branch fully, you must:

- Also merge the `users` branch in hymnal-server, and push it to your server
- Take the `squad.players` property from your `roster` Mongo collection, and move it into a top-level `players` property. Delete `squad` afterwards.
- Push the new app release to Expo after verifying the changes locally.
- Create a `users` collection inside your production database
- Navigate to your CRUD server's address in a browser
- Register a new account. DO NOT LOGIN YET.
- Edit the new record in `users` to give yourself permissions. (They're just booleans.)
- Send a push notification to your users asking them to restart the app. Otherwise, people who leave it running will have an old version running that expects the old structure. (As a bonus, this step verifies that you have everything else working.)

You'll now have the refactored roster code that fully supports multiple rosters, as well as user accounts with the new auth ready!