### PR TITLE
Add a Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,21 @@
+REACT_NATIVE_PACKAGER_HOSTNAME = Socket.ip_address_list.find { |ai| ai.ipv4? && !ai.ipv4_loopback? }.ip_address
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.provision :shell, path: "vagrant-bootstrap.sh"
+  #config.vm.network "public_network", ip: "192.168.1.9"
+  config.vm.network "forwarded_port", guest: 19000, host: 19000
+  config.vm.network "forwarded_port", guest: 19001, host: 19001
+  config.vm.network "forwarded_port", guest: 19002, host: 19002
+
+  config.vm.provision "set_lan_ip", "type": "shell" do |installs|
+    installs.inline = "
+      echo 'export REACT_NATIVE_PACKAGER_HOSTNAME=#{REACT_NATIVE_PACKAGER_HOSTNAME}' >> /home/vagrant/.bashrc
+    "
+  end
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+    v.cpus = 3
+  end
+end

--- a/vagrant-bootstrap.sh
+++ b/vagrant-bootstrap.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
+sudo apt-get install -y nodejs
+npm install -g expo-cli
+echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf && sysctl -p


### PR DESCRIPTION
Coming in on a hot streak of PRs that will make my fellow maintainers ask "what is this even", it's [Vagrant](https://www.vagrantup.com/) support for the app repo!

The short version: if you have Vagrant and Virtualbox installed, running "vagrant up" in the project root will automatically provision a Ubuntu 18.04 instance for you, forward the ports needed for the Expo packager to work, and install node + expo for you. You can then run vagrant ssh to get inside, with the project's root stored at /vagrant.

So no matter what weird system you're on, you can now get up and running on a fresh git clone with:

- vagrant up
- vagrant ssh
- cd /vagrant
- npm install
- expo start