### PR TITLE
News feed crash fix

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -489,6 +489,7 @@ class Post extends React.Component {
           let player = this.props.globalData.state.players.find(
             (player) => player._id === attachment.relatedId
           );
+          if(player === undefined) break;
           let playerDisplay = (
             <PostAttachmentPlayer
               key={index}


### PR DESCRIPTION
If a player showed up as `undefined`, the app could crash. This just avoids rendering the attachment in the news feed; if the data wasn't available to begin with, it's probably historical data (e.g. inactive roster).